### PR TITLE
preserve error code from rest-client exceptions

### DIFF
--- a/ruby/lib/http_client.rb
+++ b/ruby/lib/http_client.rb
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 # encoding: UTF-8
 #
-# Copyright © 2016 Cask Data, Inc.
+# Copyright © 2017 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -29,7 +29,9 @@ module CmApi
       @code = nil
       @message = error.to_s
 
-      @code = error.code if error.respond_to?(:code)
+      if error.respond_to?(:response)
+        @code = error.response.code if error.response.respond_to?(:code)
+      end
     end
   end
 
@@ -95,8 +97,7 @@ module CmApi
       begin
         ::RestClient::Request.execute(rest_client_args)
       rescue => e
-        puts e.inspect
-        raise @exc_class, e
+        raise @exc_class.new(e)
       end
     end
 


### PR DESCRIPTION
rest-client includes the entire response in the exception.  this pulls the response code from there, and sets it as the `code` attribute in any RestException thrown